### PR TITLE
fix: python_ocr not deleting temp files

### DIFF
--- a/apps/python-ocr/fanyi_ocr.py
+++ b/apps/python-ocr/fanyi_ocr.py
@@ -1,8 +1,45 @@
+import glob
 import os
 import json
+from shutil import rmtree
 import sys
 import easyocr
 import jieba
+
+def handle_pyinstaller_folders():
+    try:
+        # pylint: disable=protected-access,no-member
+        base_path = sys._MEIPASS
+
+        # Create a file "fanyi" in this folder
+        # This acts as an indicator that this folder belongs to fanyi
+        open(os.path.join(base_path, 'fanyi'), encoding='utf-8', mode = 'w').close()
+
+        # Go to parent folder of MEIPASS
+        temp_dir = os.path.abspath(os.path.join(base_path, '..'))
+
+        temp_folders = glob.glob(os.path.join(temp_dir, '_MEI*'))
+
+        print(f"Found {len(temp_folders)} temp folders matching _MEI* pattern", file=sys.stderr)
+
+        for folder in temp_folders:
+            # Check if file "fanyi" exists in the folder
+            if not os.path.exists(os.path.join(folder, 'fanyi')):
+                print(f"Folder {folder} does not contain file 'fanyi', skipping delete", file=sys.stderr)
+                continue
+
+            # Check that this isn't the current temp file being used
+            if folder == base_path:
+                print(f"Folder {folder} is the current temp file being used, skipping delete", file=sys.stderr)
+                continue
+
+            # Delete old folder
+            print(f"Deleting old folder: {folder}", file=sys.stderr)
+            rmtree(folder)
+    except Exception:
+        print("Exception occurred when trying to handle PyInstaller folders", file=sys.stderr)
+        print(Exception, file=sys.stderr)
+        return
 
 
 def ocr_and_segment(image_path, reader):
@@ -49,6 +86,8 @@ def main():
         file=sys.stderr,
     )
 
+    handle_pyinstaller_folders()
+
     try:
         # Initialize EasyOCR reader once
         reader = easyocr.Reader(["ch_sim"])
@@ -92,8 +131,7 @@ def main():
 
             elif command == "exit":
                 print("Received 'exit' command. Shutting down.", file=sys.stderr)
-                break
-
+                sys.exit(0)
             elif not command:
                 # This case handles EOF (End of File), which signifies the pipe has been closed
                 print("End of input stream detected. Shutting down.", file=sys.stderr)


### PR DESCRIPTION
This issue occurs due to improper shutdown of the child Python OCR process spawned by Electron when running the application. The child process is unable to clean up properly when the main Electron application is terminated, leaving behind the unpacked Python application in the OS' `temp` directory. This leads to the storage usage by the application ballooning significantly in size.

This PR implements a system that will help to maintain the temp folder:
- As per usual, when the application is launched, the child process is spawned and the Python app is unpacked into the temp directory
- Python OCR creates a file `fanyi` inside the current temp directory to indicate that the `temp` directory belongs to fanyi
- It runs a clean up to remove other files matching the temp directory pattern name

Closes #67 