### PR TITLE
chore: split missing entries into root words

### DIFF
--- a/apps/fanyi/src/main/services/dictionary.ts
+++ b/apps/fanyi/src/main/services/dictionary.ts
@@ -177,6 +177,40 @@ export function getDictionaryEntriesFromAllDictionaries(queries: string[]) {
   );
 }
 
+function findAndAppendInDictionaries(
+  entryMap: Record<string, DictionaryEntry>,
+  dictionaries: Dictionary[],
+  query: string
+): boolean {
+  let isExistsInDictionaries = false;
+
+  for (const dict of dictionaries) {
+    const sourceEntry = dict.wordMap[query];
+
+    if (!sourceEntry) {
+      continue;
+    }
+
+    isExistsInDictionaries = true;
+
+    if (entryMap[query]) {
+      // Combine definition with existing query
+      entryMap[query].definitions = [
+        ...entryMap[query].definitions,
+        ...sourceEntry.definitions,
+      ];
+    } else {
+      // If not, add the entry
+      entryMap[query] = {
+        ...sourceEntry,
+        definitions: [...sourceEntry.definitions],
+      };
+    }
+  }
+
+  return isExistsInDictionaries;
+}
+
 export function getDictionaryEntries(
   dictionaries: Dictionary[],
   queries: string[]
@@ -192,31 +226,22 @@ export function getDictionaryEntries(
   const querySet = new Set(queries);
 
   for (const query of querySet) {
-    for (const dict of dictionaries) {
-      const sourceEntry = dict.wordMap[query];
+    const isExistsInDictionaries = findAndAppendInDictionaries(
+      entryMap,
+      dictionaries,
+      query
+    );
 
-      if (!sourceEntry) {
-        // Skip if entry not found
-        continue;
-      }
+    if (!isExistsInDictionaries) {
+      // Break the word into individual entries
+      const individualEntries = query.split('');
 
-      if (entryMap[query]) {
-        // Combine definition with existing query
-        entryMap[query].definitions = [
-          ...entryMap[query].definitions,
-          ...sourceEntry.definitions,
-        ];
-      } else {
-        // If not, add the entry
-        entryMap[query] = {
-          ...sourceEntry,
-          definitions: [...sourceEntry.definitions],
-        };
+      for (const entry of individualEntries) {
+        findAndAppendInDictionaries(entryMap, dictionaries, entry);
       }
     }
   }
-
-  return Object.values(entryMap).filter((entry) => entry !== undefined);
+  return Object.values(entryMap);
 }
 
 export function getDictionaryEntry(query: string) {


### PR DESCRIPTION
Handles the case where entries that didn't have a corresponding definition wouldn't show up in the results
- This PR makes it such that words will be split into their root words

# Before

<img width="2070" height="765" alt="image" src="https://github.com/user-attachments/assets/1595cc55-b393-49c2-abdd-a4f0a6bc2947" />

# After

<img width="2148" height="832" alt="image" src="https://github.com/user-attachments/assets/3d885ca5-8b9a-46ed-bd49-b0468b911992" />
